### PR TITLE
log jwt proxy mutations

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -78,9 +78,7 @@ services:
       OIDC_USERINFO_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/userinfo"
       OIDC_TOKEN_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token"
       OIDC_TOKEN_INTROSPECTION_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token/introspect"
-      # TODO change to INTERNAL_FHIR_API
-      # TODO switch to external API (requiring auth)
-      MAP_API: "http://fhir-internal:8080/fhir/"
+      MAP_API: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir/'
       # FHIR URL passed to SoF client
       SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'
       SOF_CLIENTS: '[{"id":"PUBCLIENT", "label":"React Public Client", "launch_url":"https://pubclient.${BASE_DOMAIN:-localtest.me}/launch.html"},{"id":"CONFIDENTIALCLIENT", "label":"React Confidential Client", "launch_url":"https://confidentialbackend.${BASE_DOMAIN:-localtest.me}/auth/launch"},{"id":"VUECLIENT", "label":"Vue Public Client", "launch_url":"https://vueclient.${BASE_DOMAIN:-localtest.me}/launch.html", "required_roles": ["clinician"]}]'
@@ -141,6 +139,7 @@ services:
     env_file:
       fhirwall.env
     environment:
+      LOGSERVER_URL: "https://logs.${BASE_DOMAIN:-localtest.me}"
       OIDC_AUTHORIZE_URL: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/auth"
       OIDC_TOKEN_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token"
       OIDC_TOKEN_INTROSPECTION_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token/introspect"
@@ -165,6 +164,7 @@ services:
       - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
     depends_on:
       - fhir
+      - logs
     networks:
       - ingress
       - internal

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -78,6 +78,7 @@ services:
       OIDC_USERINFO_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/userinfo"
       OIDC_TOKEN_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token"
       OIDC_TOKEN_INTROSPECTION_URI: "https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token/introspect"
+      # TODO change to INTERNAL_FHIR_API
       MAP_API: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir/'
       # FHIR URL passed to SoF client
       SOF_HOST_FHIR_URL: 'https://fhirwall.${BASE_DOMAIN:-localtest.me}/fhir'

--- a/dev/fhirwall.env.default
+++ b/dev/fhirwall.env.default
@@ -5,4 +5,7 @@
 # Variables defined in this file will only be available to containers/images
 # ie not for interpolation in docker-compose YAML files
 
+# JWT with embeded secret to match PGRST_JWT_SECRET from logs.env
+LOGSERVER_TOKEN=
+
 SECRET_KEY=


### PR DESCRIPTION
configuration changes needed to incorporate logserver in jwt-proxy to capture FHIR mutations as part of https://github.com/uwcirg/jwt-proxy/pull/6